### PR TITLE
Add soft fail and soft fail message to users

### DIFF
--- a/src/api/actions/helpers.ts
+++ b/src/api/actions/helpers.ts
@@ -7,7 +7,8 @@ export const makeApiCall = async <T>(
   url: string,
   method: "GET" | "POST",
   body?: string | Record<string, unknown>,
-  softFail?: boolean
+  softFail?: boolean,
+  softFailMessage?: string
 ): Promise<T> => {
   const headers: Record<string, string> = {};
 
@@ -28,8 +29,14 @@ export const makeApiCall = async <T>(
     throw Error(`Request failed with code ${res.status}: ${await res.text()}`);
   }
 
-  const returnedBody = await res.json();
-  return returnedBody as T;
+  if (softFail) {
+    const returnedBody = await res.json();
+    returnedBody["softFailMessage"] = softFailMessage;
+    return returnedBody as T;
+  } else {
+    const returnedBody = await res.json();
+    return returnedBody as T;
+  }
 };
 
 export const convertBidDtoToBid = (bid: BidDto): Bid => {

--- a/src/api/actions/submitCancelMessage.ts
+++ b/src/api/actions/submitCancelMessage.ts
@@ -7,9 +7,18 @@ export const submitCancelMessage = async (
 ): Promise<void> => {
   const uri = `${apiUrl}/bid/cancel`;
 
-  // Soft fail if the bid isn't found
-  await makeApiCall(uri, "POST", {
-    cancelMessageSignature: signedCancelMessage,
-    bidMessageSignature: signedBidMessage,
-  }, true);
+  const softFailMessage =
+    "Already cancelled in the API but allowing execution to continue to cancel in the contract as well";
+
+  // Soft fail if the bid isn't found in the API
+  await makeApiCall(
+    uri,
+    "POST",
+    {
+      cancelMessageSignature: signedCancelMessage,
+      bidMessageSignature: signedBidMessage,
+    },
+    true,
+    softFailMessage
+  );
 };


### PR DESCRIPTION
A soft fail happens when someone calls to cancel a bid through the SDK but it is already canceled through the API. It is possible still that it hasn't been canceled with the smart contract and so instead of throwing an error we notify the user with a message that a soft fail has occured, but continue execution