### PR TITLE
Update code to match new ABI from updated zAuction

### DIFF
--- a/abi/ZAuction.json
+++ b/abi/ZAuction.json
@@ -9,7 +9,7 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "auctionId",
+          "name": "bidNonce",
           "type": "uint256"
         },
         {
@@ -58,7 +58,7 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "auctionId",
+          "name": "bidNonce",
           "type": "uint256"
         },
         {
@@ -69,6 +69,25 @@
         }
       ],
       "name": "BidCancelled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "BuyNowPriceSet",
       "type": "event"
     },
     {
@@ -136,7 +155,7 @@
         },
         {
           "internalType": "uint256",
-          "name": "auctionId",
+          "name": "bidNonce",
           "type": "uint256"
         },
         {
@@ -250,7 +269,7 @@
         },
         {
           "internalType": "uint256",
-          "name": "auctionId",
+          "name": "bidNonce",
           "type": "uint256"
         }
       ],
@@ -287,7 +306,7 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "auctionId",
+          "name": "bidNonce",
           "type": "uint256"
         },
         {
@@ -333,49 +352,13 @@
       "type": "function"
     },
     {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "auctionId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "bid",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "nftAddress",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "tokenId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "minbid",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "startBlock",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "expireBlock",
-          "type": "uint256"
-        }
-      ],
-      "name": "createLegacyBid",
+      "inputs": [],
+      "name": "hub",
       "outputs": [
         {
-          "internalType": "bytes32",
-          "name": "data",
-          "type": "bytes32"
+          "internalType": "contract IZNSHub",
+          "name": "",
+          "type": "address"
         }
       ],
       "stateMutability": "view",
@@ -392,16 +375,24 @@
           "internalType": "contract IRegistrar",
           "name": "registrarAddress",
           "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "legacyZAuctionAddress",
-          "type": "address"
         }
       ],
       "name": "initialize",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "legacyRegistrar",
+      "outputs": [
+        {
+          "internalType": "contract IRegistrar",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {
@@ -419,6 +410,11 @@
     },
     {
       "inputs": [
+        {
+          "internalType": "contract IRegistrar",
+          "name": "",
+          "type": "address"
+        },
         {
           "internalType": "uint256",
           "name": "",
@@ -467,19 +463,6 @@
     },
     {
       "inputs": [],
-      "name": "registrar",
-      "outputs": [
-        {
-          "internalType": "contract IRegistrar",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
       "name": "renounceOwnership",
       "outputs": [],
       "stateMutability": "nonpayable",
@@ -517,6 +500,19 @@
         }
       ],
       "name": "setTopLevelDomainFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IZNSHub",
+          "name": "hubAddress",
+          "type": "address"
+        }
+      ],
+      "name": "setZNSHub",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/abi/ZAuction.json
+++ b/abi/ZAuction.json
@@ -411,11 +411,6 @@
     {
       "inputs": [
         {
-          "internalType": "contract IRegistrar",
-          "name": "",
-          "type": "address"
-        },
-        {
           "internalType": "uint256",
           "name": "",
           "type": "uint256"

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -10,7 +10,7 @@ import {
 
 export const getZAuctionContract = async (
   web3Provider: ethers.providers.Provider | ethers.Signer,
-  address: string
+  address: string // to change on new deployment
 ): Promise<ZAuction> => {
   const contract = ZAuction__factory.connect(address, web3Provider);
   return contract;

--- a/src/contracts/types/ZAuction.d.ts
+++ b/src/contracts/types/ZAuction.d.ts
@@ -32,7 +32,7 @@ interface ZAuctionInterface extends ethers.utils.Interface {
     "initialize(address,address)": FunctionFragment;
     "legacyRegistrar()": FunctionFragment;
     "owner()": FunctionFragment;
-    "priceInfo(address,uint256)": FunctionFragment;
+    "priceInfo(uint256)": FunctionFragment;
     "recover(bytes32,bytes)": FunctionFragment;
     "renounceOwnership()": FunctionFragment;
     "setBuyPrice(uint256,uint256)": FunctionFragment;
@@ -103,7 +103,7 @@ interface ZAuctionInterface extends ethers.utils.Interface {
   encodeFunctionData(functionFragment: "owner", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "priceInfo",
-    values: [string, BigNumberish]
+    values: [BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "recover",
@@ -326,8 +326,7 @@ export class ZAuction extends BaseContract {
     owner(overrides?: CallOverrides): Promise<[string]>;
 
     priceInfo(
-      arg0: string,
-      arg1: BigNumberish,
+      arg0: BigNumberish,
       overrides?: CallOverrides
     ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -452,8 +451,7 @@ export class ZAuction extends BaseContract {
   owner(overrides?: CallOverrides): Promise<string>;
 
   priceInfo(
-    arg0: string,
-    arg1: BigNumberish,
+    arg0: BigNumberish,
     overrides?: CallOverrides
   ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -578,8 +576,7 @@ export class ZAuction extends BaseContract {
     owner(overrides?: CallOverrides): Promise<string>;
 
     priceInfo(
-      arg0: string,
-      arg1: BigNumberish,
+      arg0: BigNumberish,
       overrides?: CallOverrides
     ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -764,8 +761,7 @@ export class ZAuction extends BaseContract {
     owner(overrides?: CallOverrides): Promise<BigNumber>;
 
     priceInfo(
-      arg0: string,
-      arg1: BigNumberish,
+      arg0: BigNumberish,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -891,8 +887,7 @@ export class ZAuction extends BaseContract {
     owner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     priceInfo(
-      arg0: string,
-      arg1: BigNumberish,
+      arg0: BigNumberish,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 

--- a/src/contracts/types/ZAuction.d.ts
+++ b/src/contracts/types/ZAuction.d.ts
@@ -28,15 +28,16 @@ interface ZAuctionInterface extends ethers.utils.Interface {
     "cancelBid(address,uint256)": FunctionFragment;
     "consumed(address,uint256)": FunctionFragment;
     "createBid(uint256,uint256,address,uint256,uint256,uint256,uint256)": FunctionFragment;
-    "createLegacyBid(uint256,uint256,address,uint256,uint256,uint256,uint256)": FunctionFragment;
-    "initialize(address,address,address)": FunctionFragment;
+    "hub()": FunctionFragment;
+    "initialize(address,address)": FunctionFragment;
+    "legacyRegistrar()": FunctionFragment;
     "owner()": FunctionFragment;
-    "priceInfo(uint256)": FunctionFragment;
+    "priceInfo(address,uint256)": FunctionFragment;
     "recover(bytes32,bytes)": FunctionFragment;
-    "registrar()": FunctionFragment;
     "renounceOwnership()": FunctionFragment;
     "setBuyPrice(uint256,uint256)": FunctionFragment;
     "setTopLevelDomainFee(uint256,uint256)": FunctionFragment;
+    "setZNSHub(address)": FunctionFragment;
     "toEthSignedMessageHash(bytes32)": FunctionFragment;
     "token()": FunctionFragment;
     "topLevelDomainFee(uint256)": FunctionFragment;
@@ -90,32 +91,24 @@ interface ZAuctionInterface extends ethers.utils.Interface {
       BigNumberish
     ]
   ): string;
-  encodeFunctionData(
-    functionFragment: "createLegacyBid",
-    values: [
-      BigNumberish,
-      BigNumberish,
-      string,
-      BigNumberish,
-      BigNumberish,
-      BigNumberish,
-      BigNumberish
-    ]
-  ): string;
+  encodeFunctionData(functionFragment: "hub", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "initialize",
-    values: [string, string, string]
+    values: [string, string]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "legacyRegistrar",
+    values?: undefined
   ): string;
   encodeFunctionData(functionFragment: "owner", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "priceInfo",
-    values: [BigNumberish]
+    values: [string, BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "recover",
     values: [BytesLike, BytesLike]
   ): string;
-  encodeFunctionData(functionFragment: "registrar", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "renounceOwnership",
     values?: undefined
@@ -128,6 +121,7 @@ interface ZAuctionInterface extends ethers.utils.Interface {
     functionFragment: "setTopLevelDomainFee",
     values: [BigNumberish, BigNumberish]
   ): string;
+  encodeFunctionData(functionFragment: "setZNSHub", values: [string]): string;
   encodeFunctionData(
     functionFragment: "toEthSignedMessageHash",
     values: [BytesLike]
@@ -163,15 +157,15 @@ interface ZAuctionInterface extends ethers.utils.Interface {
   decodeFunctionResult(functionFragment: "cancelBid", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "consumed", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "createBid", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "hub", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "initialize", data: BytesLike): Result;
   decodeFunctionResult(
-    functionFragment: "createLegacyBid",
+    functionFragment: "legacyRegistrar",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "initialize", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "priceInfo", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "recover", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "registrar", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "renounceOwnership",
     data: BytesLike
@@ -184,6 +178,7 @@ interface ZAuctionInterface extends ethers.utils.Interface {
     functionFragment: "setTopLevelDomainFee",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "setZNSHub", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "toEthSignedMessageHash",
     data: BytesLike
@@ -209,12 +204,14 @@ interface ZAuctionInterface extends ethers.utils.Interface {
   events: {
     "BidAccepted(uint256,address,address,uint256,address,uint256,uint256)": EventFragment;
     "BidCancelled(uint256,address)": EventFragment;
+    "BuyNowPriceSet(uint256,uint256)": EventFragment;
     "DomainSold(address,address,uint256,address,uint256)": EventFragment;
     "OwnershipTransferred(address,address)": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "BidAccepted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "BidCancelled"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "BuyNowPriceSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "DomainSold"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
 }
@@ -265,7 +262,7 @@ export class ZAuction extends BaseContract {
   functions: {
     acceptBid(
       signature: BytesLike,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bidder: string,
       bid: BigNumberish,
       tokenId: BigNumberish,
@@ -295,7 +292,7 @@ export class ZAuction extends BaseContract {
 
     cancelBid(
       account: string,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
@@ -306,7 +303,7 @@ export class ZAuction extends BaseContract {
     ): Promise<[boolean]>;
 
     createBid(
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bid: BigNumberish,
       nftAddress: string,
       tokenId: BigNumberish,
@@ -316,28 +313,21 @@ export class ZAuction extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string] & { data: string }>;
 
-    createLegacyBid(
-      auctionId: BigNumberish,
-      bid: BigNumberish,
-      nftAddress: string,
-      tokenId: BigNumberish,
-      minbid: BigNumberish,
-      startBlock: BigNumberish,
-      expireBlock: BigNumberish,
-      overrides?: CallOverrides
-    ): Promise<[string] & { data: string }>;
+    hub(overrides?: CallOverrides): Promise<[string]>;
 
     initialize(
       tokenAddress: string,
       registrarAddress: string,
-      legacyZAuctionAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
+
+    legacyRegistrar(overrides?: CallOverrides): Promise<[string]>;
 
     owner(overrides?: CallOverrides): Promise<[string]>;
 
     priceInfo(
-      arg0: BigNumberish,
+      arg0: string,
+      arg1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -346,8 +336,6 @@ export class ZAuction extends BaseContract {
       signature: BytesLike,
       overrides?: CallOverrides
     ): Promise<[string]>;
-
-    registrar(overrides?: CallOverrides): Promise<[string]>;
 
     renounceOwnership(
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -362,6 +350,11 @@ export class ZAuction extends BaseContract {
     setTopLevelDomainFee(
       id: BigNumberish,
       amount: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<ContractTransaction>;
+
+    setZNSHub(
+      hubAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<ContractTransaction>;
 
@@ -395,7 +388,7 @@ export class ZAuction extends BaseContract {
 
   acceptBid(
     signature: BytesLike,
-    auctionId: BigNumberish,
+    bidNonce: BigNumberish,
     bidder: string,
     bid: BigNumberish,
     tokenId: BigNumberish,
@@ -425,7 +418,7 @@ export class ZAuction extends BaseContract {
 
   cancelBid(
     account: string,
-    auctionId: BigNumberish,
+    bidNonce: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
@@ -436,7 +429,7 @@ export class ZAuction extends BaseContract {
   ): Promise<boolean>;
 
   createBid(
-    auctionId: BigNumberish,
+    bidNonce: BigNumberish,
     bid: BigNumberish,
     nftAddress: string,
     tokenId: BigNumberish,
@@ -446,28 +439,21 @@ export class ZAuction extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string>;
 
-  createLegacyBid(
-    auctionId: BigNumberish,
-    bid: BigNumberish,
-    nftAddress: string,
-    tokenId: BigNumberish,
-    minbid: BigNumberish,
-    startBlock: BigNumberish,
-    expireBlock: BigNumberish,
-    overrides?: CallOverrides
-  ): Promise<string>;
+  hub(overrides?: CallOverrides): Promise<string>;
 
   initialize(
     tokenAddress: string,
     registrarAddress: string,
-    legacyZAuctionAddress: string,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
+
+  legacyRegistrar(overrides?: CallOverrides): Promise<string>;
 
   owner(overrides?: CallOverrides): Promise<string>;
 
   priceInfo(
-    arg0: BigNumberish,
+    arg0: string,
+    arg1: BigNumberish,
     overrides?: CallOverrides
   ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -476,8 +462,6 @@ export class ZAuction extends BaseContract {
     signature: BytesLike,
     overrides?: CallOverrides
   ): Promise<string>;
-
-  registrar(overrides?: CallOverrides): Promise<string>;
 
   renounceOwnership(
     overrides?: Overrides & { from?: string | Promise<string> }
@@ -492,6 +476,11 @@ export class ZAuction extends BaseContract {
   setTopLevelDomainFee(
     id: BigNumberish,
     amount: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<ContractTransaction>;
+
+  setZNSHub(
+    hubAddress: string,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<ContractTransaction>;
 
@@ -525,7 +514,7 @@ export class ZAuction extends BaseContract {
   callStatic: {
     acceptBid(
       signature: BytesLike,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bidder: string,
       bid: BigNumberish,
       tokenId: BigNumberish,
@@ -555,7 +544,7 @@ export class ZAuction extends BaseContract {
 
     cancelBid(
       account: string,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -566,7 +555,7 @@ export class ZAuction extends BaseContract {
     ): Promise<boolean>;
 
     createBid(
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bid: BigNumberish,
       nftAddress: string,
       tokenId: BigNumberish,
@@ -576,28 +565,21 @@ export class ZAuction extends BaseContract {
       overrides?: CallOverrides
     ): Promise<string>;
 
-    createLegacyBid(
-      auctionId: BigNumberish,
-      bid: BigNumberish,
-      nftAddress: string,
-      tokenId: BigNumberish,
-      minbid: BigNumberish,
-      startBlock: BigNumberish,
-      expireBlock: BigNumberish,
-      overrides?: CallOverrides
-    ): Promise<string>;
+    hub(overrides?: CallOverrides): Promise<string>;
 
     initialize(
       tokenAddress: string,
       registrarAddress: string,
-      legacyZAuctionAddress: string,
       overrides?: CallOverrides
     ): Promise<void>;
+
+    legacyRegistrar(overrides?: CallOverrides): Promise<string>;
 
     owner(overrides?: CallOverrides): Promise<string>;
 
     priceInfo(
-      arg0: BigNumberish,
+      arg0: string,
+      arg1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<[BigNumber, string] & { price: BigNumber; holder: string }>;
 
@@ -606,8 +588,6 @@ export class ZAuction extends BaseContract {
       signature: BytesLike,
       overrides?: CallOverrides
     ): Promise<string>;
-
-    registrar(overrides?: CallOverrides): Promise<string>;
 
     renounceOwnership(overrides?: CallOverrides): Promise<void>;
 
@@ -622,6 +602,8 @@ export class ZAuction extends BaseContract {
       amount: BigNumberish,
       overrides?: CallOverrides
     ): Promise<void>;
+
+    setZNSHub(hubAddress: string, overrides?: CallOverrides): Promise<void>;
 
     toEthSignedMessageHash(
       hash: BytesLike,
@@ -653,7 +635,7 @@ export class ZAuction extends BaseContract {
 
   filters: {
     BidAccepted(
-      auctionId?: null,
+      bidNonce?: null,
       bidder?: string | null,
       seller?: string | null,
       amount?: null,
@@ -663,7 +645,7 @@ export class ZAuction extends BaseContract {
     ): TypedEventFilter<
       [BigNumber, string, string, BigNumber, string, BigNumber, BigNumber],
       {
-        auctionId: BigNumber;
+        bidNonce: BigNumber;
         bidder: string;
         seller: string;
         amount: BigNumber;
@@ -674,11 +656,19 @@ export class ZAuction extends BaseContract {
     >;
 
     BidCancelled(
-      auctionId?: null,
+      bidNonce?: null,
       bidder?: string | null
     ): TypedEventFilter<
       [BigNumber, string],
-      { auctionId: BigNumber; bidder: string }
+      { bidNonce: BigNumber; bidder: string }
+    >;
+
+    BuyNowPriceSet(
+      tokenId?: BigNumberish | null,
+      amount?: null
+    ): TypedEventFilter<
+      [BigNumber, BigNumber],
+      { tokenId: BigNumber; amount: BigNumber }
     >;
 
     DomainSold(
@@ -710,7 +700,7 @@ export class ZAuction extends BaseContract {
   estimateGas: {
     acceptBid(
       signature: BytesLike,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bidder: string,
       bid: BigNumberish,
       tokenId: BigNumberish,
@@ -740,7 +730,7 @@ export class ZAuction extends BaseContract {
 
     cancelBid(
       account: string,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
@@ -751,7 +741,7 @@ export class ZAuction extends BaseContract {
     ): Promise<BigNumber>;
 
     createBid(
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bid: BigNumberish,
       nftAddress: string,
       tokenId: BigNumberish,
@@ -761,28 +751,21 @@ export class ZAuction extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
-    createLegacyBid(
-      auctionId: BigNumberish,
-      bid: BigNumberish,
-      nftAddress: string,
-      tokenId: BigNumberish,
-      minbid: BigNumberish,
-      startBlock: BigNumberish,
-      expireBlock: BigNumberish,
-      overrides?: CallOverrides
-    ): Promise<BigNumber>;
+    hub(overrides?: CallOverrides): Promise<BigNumber>;
 
     initialize(
       tokenAddress: string,
       registrarAddress: string,
-      legacyZAuctionAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
+
+    legacyRegistrar(overrides?: CallOverrides): Promise<BigNumber>;
 
     owner(overrides?: CallOverrides): Promise<BigNumber>;
 
     priceInfo(
-      arg0: BigNumberish,
+      arg0: string,
+      arg1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -791,8 +774,6 @@ export class ZAuction extends BaseContract {
       signature: BytesLike,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
-
-    registrar(overrides?: CallOverrides): Promise<BigNumber>;
 
     renounceOwnership(
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -807,6 +788,11 @@ export class ZAuction extends BaseContract {
     setTopLevelDomainFee(
       id: BigNumberish,
       amount: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    setZNSHub(
+      hubAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<BigNumber>;
 
@@ -841,7 +827,7 @@ export class ZAuction extends BaseContract {
   populateTransaction: {
     acceptBid(
       signature: BytesLike,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bidder: string,
       bid: BigNumberish,
       tokenId: BigNumberish,
@@ -871,7 +857,7 @@ export class ZAuction extends BaseContract {
 
     cancelBid(
       account: string,
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 
@@ -882,7 +868,7 @@ export class ZAuction extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     createBid(
-      auctionId: BigNumberish,
+      bidNonce: BigNumberish,
       bid: BigNumberish,
       nftAddress: string,
       tokenId: BigNumberish,
@@ -892,28 +878,21 @@ export class ZAuction extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
-    createLegacyBid(
-      auctionId: BigNumberish,
-      bid: BigNumberish,
-      nftAddress: string,
-      tokenId: BigNumberish,
-      minbid: BigNumberish,
-      startBlock: BigNumberish,
-      expireBlock: BigNumberish,
-      overrides?: CallOverrides
-    ): Promise<PopulatedTransaction>;
+    hub(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     initialize(
       tokenAddress: string,
       registrarAddress: string,
-      legacyZAuctionAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
+
+    legacyRegistrar(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     owner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     priceInfo(
-      arg0: BigNumberish,
+      arg0: string,
+      arg1: BigNumberish,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
@@ -922,8 +901,6 @@ export class ZAuction extends BaseContract {
       signature: BytesLike,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
-
-    registrar(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     renounceOwnership(
       overrides?: Overrides & { from?: string | Promise<string> }
@@ -938,6 +915,11 @@ export class ZAuction extends BaseContract {
     setTopLevelDomainFee(
       id: BigNumberish,
       amount: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setZNSHub(
+      hubAddress: string,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/src/contracts/types/factories/ZAuction__factory.ts
+++ b/src/contracts/types/factories/ZAuction__factory.ts
@@ -13,7 +13,7 @@ const _abi = [
       {
         indexed: false,
         internalType: "uint256",
-        name: "auctionId",
+        name: "bidNonce",
         type: "uint256",
       },
       {
@@ -62,7 +62,7 @@ const _abi = [
       {
         indexed: false,
         internalType: "uint256",
-        name: "auctionId",
+        name: "bidNonce",
         type: "uint256",
       },
       {
@@ -73,6 +73,25 @@ const _abi = [
       },
     ],
     name: "BidCancelled",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BuyNowPriceSet",
     type: "event",
   },
   {
@@ -140,7 +159,7 @@ const _abi = [
       },
       {
         internalType: "uint256",
-        name: "auctionId",
+        name: "bidNonce",
         type: "uint256",
       },
       {
@@ -254,7 +273,7 @@ const _abi = [
       },
       {
         internalType: "uint256",
-        name: "auctionId",
+        name: "bidNonce",
         type: "uint256",
       },
     ],
@@ -291,7 +310,7 @@ const _abi = [
     inputs: [
       {
         internalType: "uint256",
-        name: "auctionId",
+        name: "bidNonce",
         type: "uint256",
       },
       {
@@ -337,49 +356,13 @@ const _abi = [
     type: "function",
   },
   {
-    inputs: [
-      {
-        internalType: "uint256",
-        name: "auctionId",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "bid",
-        type: "uint256",
-      },
-      {
-        internalType: "address",
-        name: "nftAddress",
-        type: "address",
-      },
-      {
-        internalType: "uint256",
-        name: "tokenId",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "minbid",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "startBlock",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "expireBlock",
-        type: "uint256",
-      },
-    ],
-    name: "createLegacyBid",
+    inputs: [],
+    name: "hub",
     outputs: [
       {
-        internalType: "bytes32",
-        name: "data",
-        type: "bytes32",
+        internalType: "contract IZNSHub",
+        name: "",
+        type: "address",
       },
     ],
     stateMutability: "view",
@@ -397,15 +380,23 @@ const _abi = [
         name: "registrarAddress",
         type: "address",
       },
-      {
-        internalType: "address",
-        name: "legacyZAuctionAddress",
-        type: "address",
-      },
     ],
     name: "initialize",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "legacyRegistrar",
+    outputs: [
+      {
+        internalType: "contract IRegistrar",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -423,6 +414,11 @@ const _abi = [
   },
   {
     inputs: [
+      {
+        internalType: "contract IRegistrar",
+        name: "",
+        type: "address",
+      },
       {
         internalType: "uint256",
         name: "",
@@ -471,19 +467,6 @@ const _abi = [
   },
   {
     inputs: [],
-    name: "registrar",
-    outputs: [
-      {
-        internalType: "contract IRegistrar",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
     name: "renounceOwnership",
     outputs: [],
     stateMutability: "nonpayable",
@@ -521,6 +504,19 @@ const _abi = [
       },
     ],
     name: "setTopLevelDomainFee",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract IZNSHub",
+        name: "hubAddress",
+        type: "address",
+      },
+    ],
+    name: "setZNSHub",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/src/contracts/types/factories/ZAuction__factory.ts
+++ b/src/contracts/types/factories/ZAuction__factory.ts
@@ -415,11 +415,6 @@ const _abi = [
   {
     inputs: [
       {
-        internalType: "contract IRegistrar",
-        name: "",
-        type: "address",
-      },
-      {
         internalType: "uint256",
         name: "",
         type: "uint256",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   Bid,
   BuyNowParams,
   Listing,
+  zNSHub,
 } from "./types";
 import {
   getERC721Contract,
@@ -230,7 +231,9 @@ export const createInstance = (config: Config): Instance => {
       // getBuyNowPrice should return the listing because we also
       // want to be able to confirm the holder is the domain owner
       // in the zNS-SDK downstream
-      const listing: Listing = await zAuction.priceInfo(tokenId);
+      const znsHub: zNSHub = await zAuction.hub() as unknown as zNSHub;
+      const registrar = await znsHub.getRegistrarForDomain(tokenId);
+      const listing: Listing = await zAuction.priceInfo(registrar, tokenId);
       return listing;
     },
     setBuyNowPrice: async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import {
   Bid,
   BuyNowParams,
   Listing,
-  zNSHub,
 } from "./types";
 import {
   getERC721Contract,

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,12 +228,10 @@ export const createInstance = (config: Config): Instance => {
         signer,
         config.zAuctionAddress
       );
-      // getBuyNowPrice should return the listing because we also
+      // getBuyNowPrice returns the listing because we also
       // want to be able to confirm the holder is the domain owner
       // in the zNS-SDK downstream
-      const znsHub: zNSHub = await zAuction.hub() as unknown as zNSHub;
-      const registrar = await znsHub.getRegistrarForDomain(tokenId);
-      const listing: Listing = await zAuction.priceInfo(registrar, tokenId);
+      const listing: Listing = await zAuction.priceInfo(tokenId);
       return listing;
     },
     setBuyNowPrice: async (

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,17 @@ export interface Config {
   web3Provider: ethers.providers.Web3Provider;
 }
 
+export interface zNSHub {
+  addRegistrar: (rootDomainId: string, registrar: string) => Promise<void>;
+  isController: (controllerAddress: string) => Promise<boolean>;
+  getRegistrarForDomain:(domainId: string) => Promise<string>;
+  ownerOf: (domainId: string) => Promise<string>;
+  domainExists: (domainId: string) => Promise<boolean>;
+  owner: () => Promise<string>;
+  registrarBeacon:() => Promise<string>;
+  parentOf: (domainId: string) => Promise<string>;
+}
+
 export interface Instance {
   listSales: (tokenId: string) => Promise<TokenSale[]>;
   listAllSales: () => Promise<TokenSaleCollection>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,17 +10,6 @@ export interface Config {
   web3Provider: ethers.providers.Web3Provider;
 }
 
-export interface zNSHub {
-  addRegistrar: (rootDomainId: string, registrar: string) => Promise<void>;
-  isController: (controllerAddress: string) => Promise<boolean>;
-  getRegistrarForDomain:(domainId: string) => Promise<string>;
-  ownerOf: (domainId: string) => Promise<string>;
-  domainExists: (domainId: string) => Promise<boolean>;
-  owner: () => Promise<string>;
-  registrarBeacon:() => Promise<string>;
-  parentOf: (domainId: string) => Promise<string>;
-}
-
 export interface Instance {
   listSales: (tokenId: string) => Promise<TokenSale[]>;
   listAllSales: () => Promise<TokenSaleCollection>;


### PR DESCRIPTION
Updated ABI and types mostly because the changes in zAuction are primarily internal however one SDK code change happened with how we get a domains buyNow price, which requires we now use the zNS Hub to get the appropriate registrar to then get the listing for that domain. The listing contains both the price and the current holder of that domain.

Everything in ABI and typechain is generated and can be ignored