### PR TITLE
Resolving discrepancy between api and sdk URL for "GET /BIDS/ACCOUNTS/{0}"

### DIFF
--- a/src/api/actions/listBidsForAccount.ts
+++ b/src/api/actions/listBidsForAccount.ts
@@ -9,7 +9,7 @@ export const listBidsForAccount = async (
   contract: string,
   account: string
 ): Promise<Bid[]> => {
-  const uri = `${apiUrl}/bids/accounts/${account.toLowerCase()}`;
+  const uri = `${apiUrl}/bids/accounts/${account}`;
   const response = await makeApiCall<AccountBidsDto>(uri, "GET");
 
   let bids: Bid[] = response.map((e) => convertBidDtoToBid(e));

--- a/src/api/actions/listBidsForAccount.ts
+++ b/src/api/actions/listBidsForAccount.ts
@@ -9,7 +9,7 @@ export const listBidsForAccount = async (
   contract: string,
   account: string
 ): Promise<Bid[]> => {
-  const uri = `${apiUrl}/bids/account/${account.toLowerCase()}`;
+  const uri = `${apiUrl}/bids/accounts/${account.toLowerCase()}`;
   const response = await makeApiCall<AccountBidsDto>(uri, "GET");
 
   let bids: Bid[] = response.map((e) => convertBidDtoToBid(e));


### PR DESCRIPTION
Issue described here:
https://www.loom.com/share/a6ce8aff075840d5bb9c4db6a24f446c

Looking at the code in the dAPP, it appears the zAuction SDK is calling "bids/account/{0}" whereas the  Zauction API is expecting "bids/accounts/{0}"

Relevant snippet from Zauction API:
![image](https://user-images.githubusercontent.com/25021249/160484768-75bcd72a-c611-4fe4-bf19-5cf8aa995020.png)
