### PR TITLE
Update zAuction sdk to accept a signed registrar for approvals/allowances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   getZAuctionContract,
   getZAuctionTradeToken,
 } from "./contracts";
+import { IERC721 } from "./contracts/types";
 
 export * from "./types";
 
@@ -61,7 +62,8 @@ export const createInstance = (config: Config): Instance => {
 
     isZAuctionApprovedToTransferNftByBid: async (
       account: string,
-      bid: Bid
+      bid: Bid,
+      registrar: IERC721
     ): Promise<boolean> => {
       const isVersion1 = bid.version === "1.0";
 
@@ -70,10 +72,7 @@ export const createInstance = (config: Config): Instance => {
         ? config.zAuctionLegacyAddress
         : config.zAuctionAddress;
 
-      const nftContract = await getERC721Contract(
-        config.web3Provider,
-        config.tokenContract
-      );
+      const nftContract = registrar;
 
       const isApproved = await actions.isZAuctionApprovedNftTransfer(
         account,
@@ -85,12 +84,10 @@ export const createInstance = (config: Config): Instance => {
     },
 
     isZAuctionApprovedToTransferNft: async (
-      account: string
+      account: string,
+      registrar: IERC721
     ): Promise<boolean> => {
-      const nftContract = await getERC721Contract(
-        config.web3Provider,
-        config.tokenContract
-      );
+      const nftContract = registrar;
 
       const isApproved = await actions.isZAuctionApprovedNftTransfer(
         account,
@@ -188,8 +185,8 @@ export const createInstance = (config: Config): Instance => {
     },
 
     approveZAuctionTransferNftByBid: async (
-      signer: ethers.Signer,
-      bid: Bid
+      bid: Bid,
+      registrar: IERC721
     ): Promise<ethers.ContractTransaction> => {
       const isVersion1 = bid.version === "1.0";
 
@@ -198,7 +195,7 @@ export const createInstance = (config: Config): Instance => {
         ? config.zAuctionLegacyAddress
         : config.zAuctionAddress;
 
-      const nftContract = await getERC721Contract(signer, config.tokenContract);
+      const nftContract = registrar;
 
       const tx = await nftContract.setApprovalForAll(zAuctionAddress, true);
 
@@ -206,9 +203,9 @@ export const createInstance = (config: Config): Instance => {
     },
 
     approveZAuctionTransferNft: async (
-      signer: ethers.Signer
+      registrar: IERC721
     ): Promise<ethers.ContractTransaction> => {
-      const nftContract = await getERC721Contract(signer, config.tokenContract);
+      const nftContract = registrar;
 
       const tx = await nftContract.setApprovalForAll(
         config.zAuctionAddress,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { Bid } from "./api/types";
+import { IERC721 } from "./contracts/types";
 export { Bid };
 
 export interface Config {
@@ -22,22 +23,40 @@ export interface Instance {
     signer: ethers.Signer,
     statusCallback?: PlaceBidStatusCallback
   ) => Promise<void>;
-  isZAuctionApprovedToTransferNftByBid: (account: string, bid: Bid) => Promise<boolean>;
-  isZAuctionApprovedToTransferNft: (account: string) => Promise<boolean>;
-  getZAuctionSpendAllowance: (account: string) => Promise<ethers.BigNumber>;
-  getZAuctionSpendAllowanceByBid: (account: string, bid: Bid) => Promise<ethers.BigNumber>;
+  isZAuctionApprovedToTransferNftByBid: (
+    account: string,
+    bid: Bid,
+    registrar: IERC721
+  ) => Promise<boolean>;
+  isZAuctionApprovedToTransferNft: (
+    account: string,
+    registrar: IERC721
+  ) => Promise<boolean>;
+  getZAuctionSpendAllowance: (
+    account: string,
+    registrar: IERC721
+  ) => Promise<ethers.BigNumber>;
+  getZAuctionSpendAllowanceByBid: (
+    account: string,
+    bid: Bid,
+    registrar: IERC721
+  ) => Promise<ethers.BigNumber>;
   getTradeTokenAddress: () => Promise<string>;
   approveZAuctionSpendTradeTokensByBid: (
-    signer: ethers.Signer, bid: Bid
+    signer: ethers.Signer,
+    bid: Bid,
+    registrar: IERC721
   ) => Promise<ethers.ContractTransaction>;
   approveZAuctionSpendTradeTokens: (
-    signer: ethers.Signer
+    signer: ethers.Signer,
+    registrar: IERC721
   ) => Promise<ethers.ContractTransaction>;
   approveZAuctionTransferNft: (
-    signer: ethers.Signer
+    registrar: IERC721
   ) => Promise<ethers.ContractTransaction>;
   approveZAuctionTransferNftByBid: (
-    signer: ethers.Signer, bid: Bid
+    bid: Bid,
+    registrar: IERC721
   ) => Promise<ethers.ContractTransaction>;
   acceptBid: (
     bid: Bid,


### PR DESCRIPTION
Part 2 will be removing the ability to create a zAuction instance from the zNS SDK and having zNS SDK methods call these methods. 