### PR TITLE
Rename `getBuyNowPrice` to `getBuyNowListing` to be more accurate, also remove reference to legacy call

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@typechain/ethers-v5": "7.0.1",
     "@types/chai": "4.2.21",
-    "@types/chai-as-promised": "7.1.4",
+    "@types/chai-as-promised": "7.1.5",
     "@types/mocha": "9.0.0",
     "@types/node": "16.7.13",
     "@types/sinon": "10.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,11 +407,21 @@ export const createInstance = (config: Config): Instance => {
       // want to be able to confirm the holder is the domain owner
       // in the zNS-SDK downstream
       const listing: BuyNowListing = await contract.priceInfo(tokenId);
-
+    
       if (listing.price.eq("0")) {
         throw Error(
           `Domain with ID ${tokenId} is currently not listed for buyNow`
         );
+      }
+
+      if (listing.paymentToken === ethers.constants.AddressZero) {
+        // Object is readonly, must make a new listing
+        const newListing: BuyNowListing = {
+          holder: listing.holder,
+          price: listing.price,
+          paymentToken: config.wildTokenAddress
+        }
+        return newListing;
       }
 
       return listing;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,10 @@ export const createInstance = (config: Config): Instance => {
       );
       return tokenBuys;
     },
-    listBids: async (tokenIds: string[], filter?: TokenBidFilter): Promise<TokenBidCollection> => {
+    listBids: async (
+      tokenIds: string[],
+      filter?: TokenBidFilter
+    ): Promise<TokenBidCollection> => {
       const tokenBidCollection: TokenBidCollection =
         await apiClient.listBidsForTokens(tokenIds, filter);
       return tokenBidCollection;
@@ -253,14 +256,18 @@ export const createInstance = (config: Config): Instance => {
     },
     // Return the ERC20 token used for payment in the network that domain is a part of.
     // This could be either the network payment token or the default payment token
-    getPaymentTokenForDomain: async (tokenId: string): Promise<string> => {
+    getPaymentTokenForDomain: async (
+      domainTokenId: string
+    ): Promise<string> => {
       const contract = await getZAuctionContract(
         config.web3Provider,
         config.zAuctionAddress
       );
-      const paymentToken = await contract.getPaymentTokenForDomain(tokenId);
+      const paymentToken = await contract.getPaymentTokenForDomain(
+        domainTokenId
+      );
       logger.trace(
-        `Payment token for domain with ID ${tokenId} is ${paymentToken}`
+        `Payment token for domain with ID ${domainTokenId} is ${paymentToken}`
       );
       return paymentToken;
     },
@@ -389,10 +396,10 @@ export const createInstance = (config: Config): Instance => {
     },
 
     // IF no return value then that domain is not on sale
-    getBuyNowPrice: async (tokenId: string): Promise<BuyNowListing> => {
+    getBuyNowListing: async (tokenId: string): Promise<BuyNowListing> => {
       if (!tokenId) throw Error("Must provide a valid tokenId");
 
-      let contract = await getZAuctionContract(
+      const contract = await getZAuctionContract(
         config.web3Provider,
         config.zAuctionAddress
       );
@@ -402,14 +409,11 @@ export const createInstance = (config: Config): Instance => {
       const listing: BuyNowListing = await contract.priceInfo(tokenId);
 
       if (listing.price.eq("0")) {
-        contract = await getZAuctionContract(
-          config.web3Provider,
-          config.zAuctionLegacyAddress
+        throw Error(
+          `Domain with ID ${tokenId} is currently not listed for buyNow`
         );
-
-        const listing: BuyNowListing = await contract.priceInfo(tokenId);
-        return listing;
       }
+
       return listing;
     },
     setBuyNowPrice: async (

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,7 @@ export interface Instance {
     params: BuyNowParams,
     signer: ethers.Signer
   ) => Promise<ethers.ContractTransaction>;
-  getBuyNowPrice: (tokenId: string) => Promise<BuyNowListing>;
+  getBuyNowListing: (tokenId: string) => Promise<BuyNowListing>;
   setBuyNowPrice: (
     params: BuyNowParams,
     signer: ethers.Signer

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,8 +1,11 @@
 import { ethers } from "ethers";
 import * as dotenv from "dotenv";
 import { Web3Provider } from "@ethersproject/providers";
-import { expect } from "chai";
-import { getLogger, setLogLevel } from "../src/utilities";
+import { expect, use } from "chai";
+import { getLogger } from "../src/utilities";
+import * as chaiAsPromised from "chai-as-promised";
+
+use(chaiAsPromised.default);
 
 const logger = getLogger("tests");
 
@@ -33,6 +36,8 @@ describe("SDK test", () => {
     "0x6e35a7ecbf6b6368bb8d42ee9b3dcfc8404857635036e60196931d4458c07622";
   const happyDogsYayDomain =
     "0xef19e4b21819162b1083f981cf7330e784b8cd98b0a603bd5dd02e1fc5bc7fc4";
+  const wilderCatsDomain =
+    "0x617b3c878abfceb89eb62b7a24f393569c822946bbc9175c6c65a7d2647c5402";
 
   const provider = new ethers.providers.JsonRpcProvider(process.env.INFURA_URL);
 
@@ -123,6 +128,7 @@ describe("SDK test", () => {
   });
   it("Lists buyNow sales", async () => {
     const sales: TokenBuy[] = await sdk.listBuyNowSales(wilderPancakesDomain);
+    console.log(sales);
   });
   it("List bids through the API with no filter", async () => {
     const bids: TokenBidCollection = await sdk.listBids([wilderPancakesDomain]);
@@ -229,6 +235,16 @@ describe("SDK test", () => {
     //   console.log(tx.hash);
     //   const receipt = await tx.wait(1);
     //   console.log(receipt);
+  });
+  it("Gets a buy now listed for a token that has been listed", async () => {
+    const listing = await sdk.getBuyNowListing(wilderPancakesDomain);
+    console.log(listing.price.toString());
+  });
+  it("Fails when we try to get a buyNowListing for a domain that was not listed", async () => {
+    const listing = sdk.getBuyNowListing(wilderCatsDomain);
+    await expect(listing).to.be.rejectedWith(
+      `Domain with ID ${wilderCatsDomain} is currently not listed for buyNow`
+    );
   });
   it("Sets a buy now price", async () => {
     const paymentToken = await sdk.getPaymentTokenForDomain(

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -128,7 +128,6 @@ describe("SDK test", () => {
   });
   it("Lists buyNow sales", async () => {
     const sales: TokenBuy[] = await sdk.listBuyNowSales(wilderPancakesDomain);
-    console.log(sales);
   });
   it("List bids through the API with no filter", async () => {
     const bids: TokenBidCollection = await sdk.listBids([wilderPancakesDomain]);
@@ -238,7 +237,7 @@ describe("SDK test", () => {
   });
   it("Gets a buy now listed for a token that has been listed", async () => {
     const listing = await sdk.getBuyNowListing(wilderPancakesDomain);
-    console.log(listing.price.toString());
+    expect(listing.price.toString()).to.not.eq(ethers.constants.HashZero)
   });
   it("Fails when we try to get a buyNowListing for a domain that was not listed", async () => {
     const listing = sdk.getBuyNowListing(wilderCatsDomain);

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,7 +764,7 @@
   resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-7.0.1.tgz#f9ae60ae5bd9e8ea8a996f66244147e8e74034ae"
   integrity sha512-mXEJ7LG0pOYO+MRPkHtbf30Ey9X2KAsU0wkeoVvjQIn7iAY6tB3k3s+82bbmJAUMyENbQ04RDOZit36CgSG6Gg==
 
-"@types/chai-as-promised@^7.1.5":
+"@types/chai-as-promised@7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
   integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
@@ -1091,7 +1091,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-chai-as-promised@^7.1.1:
+chai-as-promised@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
   integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,10 +764,10 @@
   resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-7.0.1.tgz#f9ae60ae5bd9e8ea8a996f66244147e8e74034ae"
   integrity sha512-mXEJ7LG0pOYO+MRPkHtbf30Ey9X2KAsU0wkeoVvjQIn7iAY6tB3k3s+82bbmJAUMyENbQ04RDOZit36CgSG6Gg==
 
-"@types/chai-as-promised@7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
-  integrity sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==
+"@types/chai-as-promised@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
   dependencies:
     "@types/chai" "*"
 
@@ -1091,7 +1091,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-chai-as-promised@7.1.1:
+chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
   integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==


### PR DESCRIPTION
We used to try to check the legacy address for buy now listings if they weren't found in the main zAuction listing, but that doesn't work because the legacy zAuction doesn't even have any buyNow functionality

fixes bug [AB#230](https://dev.azure.com/zero-wilderworld/07337eb7-a009-4103-8b97-ecb872053d7e/_workitems/edit/230)